### PR TITLE
Fix lintian warnings

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Bugs: mailto:bugs@grml.org
 Package: grml-debian-keyring
 Priority: important
 Architecture: all
-Depends: gnupg (>= 1.0.6-4)
+Depends: ${misc:Depends}, gnupg (>= 1.0.6-4)
 Description: GnuPG archive key of the grml.org repository
  The GRML repository digitally signs its Release files. This package
  contains the repository key used for that.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: grml-debian-keyring
 Section: misc
 Priority: optional
 Maintainer: Alexander Wirt <formorer@grml.org>
-Standards-Version: 3.9.2
+Standards-Version: 3.9.6
 Build-Depends: debhelper (>= 8)
 Homepage: http://git.grml.org/?p=grml-debian-keyring.git
 Vcs-git: git://git.grml.org/grml-debian-keyring.git

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 if [ -x /usr/bin/apt-key ]; then
     /usr/bin/apt-key add /usr/share/keyrings/grml-debian-keyring.gpg
 fi

--- a/debian/postinst
+++ b/debian/postinst
@@ -5,3 +5,5 @@ set -e
 if [ -x /usr/bin/apt-key ]; then
     /usr/bin/apt-key add /usr/share/keyrings/grml-debian-keyring.gpg
 fi
+
+#DEBHELPER#

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 case "$1" in
     remove|purge)
 	if [ -x /usr/bin/apt-key ]; then

--- a/debian/prerm
+++ b/debian/prerm
@@ -9,3 +9,5 @@ case "$1" in
 	fi
 	;;
 esac
+
+#DEBHELPER#


### PR DESCRIPTION
This pull request fixes various lintian warnings:
- `ancient-standards-version`
- `debhelper-but-no-misc-depends`
- `maintainer-script-lacks-debhelper-token`
- `maintainer-script-ignores-errors`

The warning `command-with-path-in-maintainer-script` is emitted for the `prerm` and `postinst` scripts, but I decided to ignore it for now. If you would like me to change that as well, just let me know.
