### PR TITLE
d/control: drop unneeded gnupg from Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,6 @@ Package: grml-keyring
 Priority: important
 Architecture: all
 Depends:
- gnupg (>= 1.0.6-4),
  ${misc:Depends},
 Replaces:
  grml-debian-keyring (<< 2024.12.08),


### PR DESCRIPTION
While redesigning grml-live, it turned out that with our new minifai implementation the apt processes inside the chroot might be horribly slow. This is caused by `gpgconf --kill all` underneath apt / apt-key trying to close tons of file descriptors:

```
| [...]
| 421751 openat(AT_FDCWD, "/etc/gcrypt/hwf.deny", O_RDONLY) = -1 ENOENT (No such file or directory) | 421751 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7f8e02ce0a10) = 421752 | 421751 wait4(421752,  <unfinished ...>
| 421752 set_robust_list(0x7f8e02ce0a20, 24) = 0
| 421752 openat(AT_FDCWD, "/dev/null", O_RDONLY) = 3 | 421752 openat(AT_FDCWD, "/dev/null", O_WRONLY) = 4 | 421752 openat(AT_FDCWD, "/dev/null", O_WRONLY) = 5
| 421752 dup2(3, 0)                       = 0
| 421752 dup2(4, 1)                       = 1
| 421752 dup2(5, 2)                       = 2
| 421752 openat(AT_FDCWD, "/proc/self/fd", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = -1 ENOENT (No such file or directory)
| 421752 prlimit64(0, RLIMIT_NOFILE, NULL, {rlim_cur=1024, rlim_max=1073741816}) = 0
| 421752 close(3)                         = 0
| 421752 close(4)                         = 0
| 421752 close(5)                         = 0
| 421752 close(6)                         = -1 EBADF (Bad file descriptor)
| 421752 close(7)                         = -1 EBADF (Bad file descriptor)
| 421752 close(8)                         = -1 EBADF (Bad file descriptor)
| 421752 close(9)                         = -1 EBADF (Bad file descriptor)
| [...]
```

We don't mount /proc inside the build chroot (AKA grml_chroot) on purpose, though gpgconf doesn't deal properly with this then.

What works around this problem is setting `ulimit -n` to something smallish, though this needs to be propagated to the build process accordingly, like:

```
| (grml_chroot)root@corazon ~ # prlimit --nofile=1024:4096 gpgconf --kill all
 | (grml_chroot)root@corazon ~ #
```
But we actually don't need gnupg as Depends of grml-keyring at all.  As it turned out, we have gnupg with its dependencies (dirmngr gnupg-l10n gnupg-utils gpg-agent gpg-wks-client gpg-wks-server gpgsm libksba8 libnpth0 pinentry-curses) on the Grml ISOs only because of this dependency.

Drop the depends on gnupg, and instead leave control of what to ship with the Grml ISOs to our package selection in grml-live.