### PR TITLE
Install /etc/apt/sources.list.d/grml.sources

### DIFF
--- a/apt.sources/grml.sources
+++ b/apt.sources/grml.sources
@@ -1,0 +1,6 @@
+Types: deb deb-src
+URIs: http://deb.grml.org
+Suites: grml-stable grml-testing
+Components: main
+Enabled: yes
+Signed-By: /usr/share/keyrings/grml-archive-keyring.pgp

--- a/debian/grml-keyring.install
+++ b/debian/grml-keyring.install
@@ -1,2 +1,3 @@
+apt.sources/grml.sources usr/share/grml-keyring
 keyrings/grml-archive-keyring.pgp usr/share/keyrings
 origins etc/dpkg

--- a/debian/grml-keyring.links
+++ b/debian/grml-keyring.links
@@ -1,1 +1,2 @@
+usr/share/grml-keyring/grml.sources etc/apt/sources.list.d/grml.sources
 usr/share/keyrings/grml-archive-keyring.pgp usr/share/keyrings/grml-archive-keyring.gpg

--- a/debian/grml-keyring.lintian-overrides
+++ b/debian/grml-keyring.lintian-overrides
@@ -1,0 +1,1 @@
+grml-keyring: package-installs-apt-sources [etc/apt/sources.list.d/grml.sources]


### PR DESCRIPTION
As a file in /usr/share and a symlink in /etc, to avoid the file becoming a conffile.

Overrides lintian warning contradicting https://wiki.debian.org/DebianRepository/UseThirdParty
Also see Debian bug #1096032.