### PR TITLE
d/control: update package description to clarify sources.list situation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,5 +26,6 @@ Provides:
 Breaks:
  grml-debian-keyring (<< 2024.12.08),
 Description: OpenPGP certificates used by the Grml project
- The Grml repository digitally signs its archive Release files. This package
- contains the OpenPGP certificates used for that repository.
+ The Grml repository digitally signs its archive Release files.
+ This package contains the OpenPGP certificates used for that repository,
+ as well as a sources.list setup for usage with apt(8).


### PR DESCRIPTION
We nowadays ship the file /usr/share/grml-keyring/grml.sources with /etc/apt/sources.list.d/grml.sources as symlink pointing to that file. So when someone installs the grml-keyring package, they might not be aware that also the Grml repositories are enabled by default, Clarify this through the package description.

Closes: https://github.com/grml/grml-keyring/issues/18