### PR TITLE
Rework grml-keyring package

### DIFF
--- a/debian/NEWS
+++ b/debian/NEWS
@@ -1,3 +1,20 @@
+grml-keyring (2025.03.10) unstable; urgency=medium
+
+  We reverted the APT sources configuration file change as shipped with
+  version 2025.02.24 due to user feedback (see e.g.
+  https://github.com/grml/grml-keyring/issues/18).
+
+  We therefore no longer ship the symlink
+  /etc/apt/sources.list.d/grml.sources pointing to
+  /usr/share/grml-keyring/grml.sources via the grml-keyring package.
+
+  If you still want to get the Grml APT repository enabled and managed
+  through the grml-keyring Debian package, you can run:
+
+    # ln -s /usr/share/grml-keyring/grml.sources /etc/apt/sources.list.d/grml.sources
+
+ -- Michael Prokop <mika@grml.org>  Mon, 10 Mar 2025 09:42:07 +0100
+
 grml-keyring (2025.02.24) unstable; urgency=medium
 
   This package now installs an APT sources configuration file.

--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -1,0 +1,17 @@
+grml-keyring
+------------
+
+The grml-keyring Debian package provides the OpenPGP certificates for
+usage with the Grml repositories, see https://deb.grml.org/ and
+https://grml.org/files/.
+
+The package also includes the APT sources configuration for the Grml
+repositories. But it does *NOT* enable the APT sources configuration
+automatically, by intention.
+
+If you want to get the Grml repositories enabled on your system, and
+managed through the grml.sources file as shipped by the grml-keyring
+Debian package, run with root permissions:
+
+  ln -s /usr/share/grml-keyring/grml.sources /etc/apt/sources.list.d/grml.sources
+  apt update

--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Package: grml-keyring
 Priority: optional
 Architecture: all
 Depends:
+ base-files (>= 9~),
  ${misc:Depends},
 Replaces:
  grml-debian-keyring (<< 2024.12.08),

--- a/debian/grml-keyring.links
+++ b/debian/grml-keyring.links
@@ -1,2 +1,1 @@
-usr/share/grml-keyring/grml.sources etc/apt/sources.list.d/grml.sources
 usr/share/keyrings/grml-archive-keyring.pgp usr/share/keyrings/grml-archive-keyring.gpg

--- a/debian/grml-keyring.lintian-overrides
+++ b/debian/grml-keyring.lintian-overrides
@@ -1,1 +1,0 @@
-grml-keyring: package-installs-apt-sources [etc/apt/sources.list.d/grml.sources]

--- a/debian/rules
+++ b/debian/rules
@@ -14,11 +14,6 @@ override_dh_auto_build: $(ARCHIVE_CERTS_SIGS)
 	cat keyrings/$(ARCHIVE_CERTS) | \
 	  $(SOP) armor >keyrings/$(ARCHIVE_KEYRING)
 
-# package should work also on older releases like lenny, which
-# don't have support for xz yet
-override_dh_builddeb:
-	dh_builddeb -- -Zgzip
-
 keyrings/%.asc: keyrings/%
 	$(SOP) verify $@ $(SIGNER_KEYRING) <keyrings/$*
 


### PR DESCRIPTION
* depend on base-files package newer than jessie
* d/rules: drop gzip workaround for older releases
* Provide debian/README.Debian to document grml.sources situation
* Provide debian/NEWS to announce grml.sources change
* Drop /etc/apt/sources.list.d/grml.sources

As discussed in issues and at Grml online meeting