### PR TITLE
apt.sources/grml.sources: fix apt-get --snapshot error

### DIFF
--- a/apt.sources/grml.sources
+++ b/apt.sources/grml.sources
@@ -3,4 +3,5 @@ URIs: http://deb.grml.org
 Suites: grml-stable grml-testing
 Components: main
 Enabled: yes
+Snapshot: disable
 Signed-By: /usr/share/keyrings/grml-archive-keyring.pgp


### PR DESCRIPTION
With an empty "Snapshot: " apt no longer throws a coredump when trying e.g. `apt-get -S 20250301 update` with an activated grml repository.