### PR TITLE
debian: Generate the .pgp keyring as binary OpenPGP keyring

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ ARCHIVE_KEYRING = grml-archive-keyring.pgp
 override_dh_auto_build: $(ARCHIVE_CERTS_SIGS)
 	@echo $(ARCHIVE_CERTS_SIGS)
 	cat keyrings/$(ARCHIVE_CERTS) | \
-	  $(SOP) armor >keyrings/$(ARCHIVE_KEYRING)
+	  $(SOP) dearmor >keyrings/$(ARCHIVE_KEYRING)
 
 keyrings/%.asc: keyrings/%
 	$(SOP) verify $@ $(SIGNER_KEYRING) <keyrings/$*


### PR DESCRIPTION
The expectation is that a .pgp (or previously .gpg) named keyring contains binary OpenPGP data, not ASCII Armor data.

Fix the SOP invocation to actually perform a dearmor, instead of an armor.

Fixes: commit 53b4adf6e6e95fbadc9a6f9b60437c5dab1beb72
Fixes: #23